### PR TITLE
fix error in blob connection's include

### DIFF
--- a/presenter/mnt_blob.ipynb
+++ b/presenter/mnt_blob.ipynb
@@ -38,7 +38,7 @@
     "extra_configs = {\"fs.azure.sas.data.coursematerial.blob.core.windows.net\":\"?sv=2018-03-28&ss=bfqt&srt=sco&sp=rwdlacup&se=2019-07-01T02:17:07Z&st=2019-02-14T19:17:07Z&spr=https&sig=1%2FnXywpfU6%2FYNLl0Zs1t5M8PF5p8ES7SPFX78tPtmYY%3D\"}\n",
     "\n",
     "try:\n",
-    "  if len(os.listdir('/dbfs/mnt/data/')) > 0:\n",
+    "  if os.path.exists('/dbfs/mnt/data/'):\n",
     "    print(\"Already mounted.\")\n",
     "  else:\n",
     "    dbutils.fs.mount(\n",


### PR DESCRIPTION
if the folder does not exists, the len() will fail. probably the code was writer after the folder was created and this was not tested